### PR TITLE
Add tests for homepage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests CI
+name: Tests
 
 on: [push]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: Tests CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test using Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: npm install
+      - run: npm test

--- a/app/__test__/page.test.tsx
+++ b/app/__test__/page.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react"
+
+import { mockedRecipes } from "@/testUtils/mockedRecipes"
+
+import Home from "../page"
+
+jest.mock("../../data/recipes.ts", () => ({
+  recipes: mockedRecipes,
+}))
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    render(<Home />)
+  })
+
+  it("displays the main heading", () => {
+    expect(
+      screen.getByRole("heading", {
+        name: "Hello foodie 👋🏻",
+      }),
+    ).toBeVisible()
+  })
+
+  it("displays the subheading", () => {
+    expect(
+      screen.getByRole("heading", {
+        name: "What do you want to cook today?",
+      }),
+    ).toBeVisible()
+  })
+
+  it("displays the section heading for the recently added recipes", () => {
+    expect(
+      screen.getByRole("heading", {
+        name: "Recently added",
+      }),
+    ).toBeVisible()
+  })
+
+  it("displays 6 recipe cards", () => {
+    expect(screen.getAllByRole("link")).toHaveLength(6)
+  })
+})

--- a/app/components/__test__/CategoryIcon.test.tsx
+++ b/app/components/__test__/CategoryIcon.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react"
+
+import CategoryIcon from "../CategoryIcon"
+
+describe("CategoryIcon", () => {
+  it("renders an element with the correct aria label for the main category", () => {
+    render(<CategoryIcon category="main" />)
+
+    expect(screen.getByLabelText("main")).toBeVisible()
+  })
+})

--- a/app/components/__test__/RecipeDetailCard.test.tsx
+++ b/app/components/__test__/RecipeDetailCard.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react"
+
+import RecipeDetailCard from "../RecipeDetailCard"
+
+describe("RecipeDetailCard", () => {
+  beforeEach(() => {
+    render(
+      <RecipeDetailCard
+        category="dessert"
+        title="Dummy recipe"
+        caloriesInfo="350 kcal/serving"
+        href="/dummy-recipe"
+      />,
+    )
+  })
+
+  it("displays the recipe card with the correct link", () => {
+    const link = screen.getByRole("link", { name: /dummy recipe/i })
+
+    expect(link).toBeVisible()
+    expect(link).toHaveAttribute("href", "/dummy-recipe")
+  })
+
+  it("displays the recipe card heading", () => {
+    expect(screen.getByRole("heading", { name: "Dummy recipe" })).toBeVisible()
+  })
+
+  it("displays the recipe card icon", () => {
+    expect(screen.getByLabelText("dessert")).toBeVisible()
+  })
+
+  it("displays the calories info", () => {
+    expect(screen.getByText("350 kcal/serving")).toBeVisible()
+  })
+})

--- a/app/helpers/__test__/getCategoryIcon.test.tsx
+++ b/app/helpers/__test__/getCategoryIcon.test.tsx
@@ -1,0 +1,23 @@
+import { BowlFood, Cookie, Grains } from "@phosphor-icons/react"
+
+import { Category } from "@/types"
+
+import { getCategoryIcon } from "../getCategoryIcon"
+
+describe("getCategoryIcon", () => {
+  it("returns the correct icon for the bread category", () => {
+    expect(getCategoryIcon("bread")).toEqual(<Grains size={24} />)
+  })
+
+  it("returns the correct icon for the dessert category", () => {
+    expect(getCategoryIcon("dessert")).toEqual(<Cookie size={24} />)
+  })
+
+  it("returns the correct icon for the main category", () => {
+    expect(getCategoryIcon("main")).toEqual(<BowlFood size={24} />)
+  })
+
+  it("throws an error for an unknown category", () => {
+    expect(() => getCategoryIcon("unknown" as Category)).toThrow("Unknown category: unknown")
+  })
+})

--- a/app/helpers/__test__/getRecipesDetails.test.ts
+++ b/app/helpers/__test__/getRecipesDetails.test.ts
@@ -1,0 +1,52 @@
+import { mockedRecipes } from "@/testUtils/mockedRecipes"
+
+import { getRecipesDetails } from "../getRecipesDetails"
+
+jest.mock("../../../data/recipes.ts", () => ({
+  recipes: mockedRecipes,
+}))
+
+describe("getRecipesDetails", () => {
+  it("returns recipes details with the correct calories info in the correct language", () => {
+    const result = getRecipesDetails()
+
+    expect(result).toEqual([
+      {
+        category: "bread",
+        title: "title1",
+        caloriesInfo: "99 kcal/kus",
+        href: "/dummy-recipe1",
+      },
+      {
+        category: "dessert",
+        title: "title2",
+        caloriesInfo: "600 kcal/piece",
+        href: "/dummy-recipe2",
+      },
+      {
+        category: "main",
+        title: "title3",
+        caloriesInfo: "133 kcal/kus",
+        href: "/dummy-recipe3",
+      },
+      {
+        category: "bread",
+        title: "title4",
+        caloriesInfo: "250 kcal/porce",
+        href: "/dummy-recipe4",
+      },
+      {
+        category: "dessert",
+        title: "title5",
+        caloriesInfo: "85 kcal/serving",
+        href: "/dummy-recipe5",
+      },
+      {
+        category: "main",
+        title: "title6",
+        caloriesInfo: "700 kcal/porcia",
+        href: "/dummy-recipe6",
+      },
+    ])
+  })
+})

--- a/app/helpers/getCategoryIcon.tsx
+++ b/app/helpers/getCategoryIcon.tsx
@@ -10,5 +10,7 @@ export const getCategoryIcon = (category: Category) => {
       return <Cookie size={24} />
     case "main":
       return <BowlFood size={24} />
+    default:
+      throw new Error(`Unknown category: ${category}`)
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,11 +17,11 @@ const Home = () => {
           </span>{" "}
           👋🏻
         </h1>
-        <p className="mt-2 text-xl font-semibold">What do you want to cook today?</p>
+        <h2 className="mt-2 text-xl font-semibold">What do you want to cook today?</h2>
       </header>
       <main className="px-4">
         <section className="mx-auto max-w-6xl">
-          <h3 className="font-semibold tracking-wide md:text-xl">Recently added</h3>
+          <h2 className="font-semibold tracking-wide md:text-xl">Recently added</h2>
           <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {recipesDetails.map(recipeDetails => (
               <RecipeDetailCard key={recipeDetails.title} {...recipeDetails} />

--- a/testUtils/mockedRecipes.ts
+++ b/testUtils/mockedRecipes.ts
@@ -1,0 +1,55 @@
+import { Recipe } from "@/types"
+
+export const mockedRecipes: Pick<
+  Recipe,
+  "id" | "category" | "language" | "amount" | "totalKcal" | "title"
+>[] = [
+  {
+    id: "dummy-recipe1",
+    category: "bread",
+    language: "czech",
+    amount: { count: 2, type: "piece" },
+    totalKcal: 199,
+    title: "title1",
+  },
+  {
+    id: "dummy-recipe2",
+    category: "dessert",
+    language: "english",
+    amount: { count: 3, type: "piece" },
+    totalKcal: 1800,
+    title: "title2",
+  },
+  {
+    id: "dummy-recipe3",
+    category: "main",
+    language: "slovak",
+    amount: { count: 3, type: "piece" },
+    totalKcal: 400,
+    title: "title3",
+  },
+  {
+    id: "dummy-recipe4",
+    category: "bread",
+    language: "czech",
+    amount: { count: 2, type: "serving" },
+    totalKcal: 500,
+    title: "title4",
+  },
+  {
+    id: "dummy-recipe5",
+    category: "dessert",
+    language: "english",
+    amount: { count: 7, type: "serving" },
+    totalKcal: 600,
+    title: "title5",
+  },
+  {
+    id: "dummy-recipe6",
+    category: "main",
+    language: "slovak",
+    amount: { count: 1, type: "serving" },
+    totalKcal: 700,
+    title: "title6",
+  },
+]


### PR DESCRIPTION
- Added default error case for the `getCategoryIcon` helper
- Changed text on the homepage to be heading instead of paragraph
- Added mocked data for recipes with selected properties used in the recipe detail component
- Added tests for all components used in the home page
- Added new workflow for tests